### PR TITLE
Another mirror in Germany

### DIFF
--- a/mirrorlist.bio
+++ b/mirrorlist.bio
@@ -29,6 +29,7 @@
 ## Germany
 ### xTom
 # Server = https://mirrors.xtom.de/bioarchlinux/$arch
+# Server = https://mirror.sunred.org/bioarchlinux/$arch
 
 ## Japan
 ### xTom
@@ -36,7 +37,7 @@
 
 ## Netherland
 ### xTom
-# Server = https://mirrors.xtom.nl/bioarchlinux/
+# Server = https://mirrors.xtom.nl/bioarchlinux/$arch
 
 ## United States
 ### xTom

--- a/mirrorlist.bio
+++ b/mirrorlist.bio
@@ -29,6 +29,7 @@
 ## Germany
 ### xTom
 # Server = https://mirrors.xtom.de/bioarchlinux/$arch
+### sunred
 # Server = https://mirror.sunred.org/bioarchlinux/$arch
 
 ## Japan


### PR DESCRIPTION
I have this mirror running for quite a while now and was recently reminded again to finally contribute my mirror to this project.
I check every 5 minutes for an update using the timestamp in the `lastupdate` file on the origin server, so the mirror should be quite closely synced without unnecessary syncs of the entire directory. The script used is a modified version of the [template](https://gitlab.archlinux.org/archlinux/infrastructure/-/blob/master/roles/syncrepo/files/syncrepo-template.sh) from the Arch Linux Project.
Additionally there are 8 sync slots open for syncing with `rsync` and `rsync-ssl` using `rsync://sync.mirror.sunred.org/bioarchlinux`. I may put the main domain behind a caching reverse proxy at some point, hence the use of a different domain for the sync endpoint.

Lastly, I noticed the dutch mirror was missing the appended `$arch` variable.
